### PR TITLE
Add gfx90a to skipIfRocm decorator

### DIFF
--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -3076,7 +3076,7 @@ class TrainerIntegrationTest(TestCasePlus, TrainerIntegrationCommon):
         self.assertIs(model_wrapped_before, model_wrapped_after, "should be not wrapped twice")
 
     @require_torch_up_to_2_accelerators
-    @skipIfRocm(arch=['gfx1201','gfx1200'])
+    @skipIfRocm(arch=['gfx1201','gfx1200','gfx90a'])
     def test_can_resume_training(self):
         # This test will fail for more than 2 GPUs since the batch size will get bigger and with the number of
         # save_steps, the checkpoint will resume training at epoch 2 or more (so the data seen by the model
@@ -3401,7 +3401,7 @@ class TrainerIntegrationTest(TestCasePlus, TrainerIntegrationCommon):
         trainer.train(resume_from_checkpoint=False)
 
     @require_torch_up_to_2_accelerators
-    @skipIfRocm(arch=['gfx1201','gfx1200'])
+    @skipIfRocm(arch=['gfx1201','gfx1200','gfx90a'])
     def test_resume_training_with_shard_checkpoint(self):
         # This test will fail for more than 2 GPUs since the batch size will get bigger and with the number of
         # save_steps, the checkpoint will resume training at epoch 2 or more (so the data seen by the model
@@ -3428,7 +3428,7 @@ class TrainerIntegrationTest(TestCasePlus, TrainerIntegrationCommon):
 
     @require_safetensors
     @require_torch_up_to_2_accelerators
-    @skipIfRocm(arch=['gfx1201','gfx1200'])
+    @skipIfRocm(arch=['gfx1201','gfx1200','gfx90a'])
     def test_resume_training_with_safe_checkpoint(self):
         # This test will fail for more than 2 GPUs since the batch size will get bigger and with the number of
         # save_steps, the checkpoint will resume training at epoch 2 or more (so the data seen by the model
@@ -3464,7 +3464,7 @@ class TrainerIntegrationTest(TestCasePlus, TrainerIntegrationCommon):
                     self.check_trainer_state_are_the_same(state, state1)
 
     @require_torch_up_to_2_accelerators
-    @skipIfRocm(arch=['gfx1201','gfx1200'])
+    @skipIfRocm(arch=['gfx1201','gfx1200','gfx90a'])
     def test_resume_training_with_gradient_accumulation(self):
         # This test will fail for more than 2 GPUs since the batch size will get bigger and with the number of
         # save_steps, the checkpoint will resume training at epoch 2 or more (so the data seen by the model
@@ -3503,7 +3503,7 @@ class TrainerIntegrationTest(TestCasePlus, TrainerIntegrationCommon):
             self.check_trainer_state_are_the_same(state, state1)
 
     @require_torch_up_to_2_accelerators
-    @skipIfRocm(arch=['gfx1201','gfx1200'])
+    @skipIfRocm(arch=['gfx1201','gfx1200','gfx90a'])
     def test_resume_training_with_frozen_params(self):
         # This test will fail for more than 2 GPUs since the batch size will get bigger and with the number of
         # save_steps, the checkpoint will resume training at epoch 2 or more (so the data seen by the model


### PR DESCRIPTION
Modifying 'ifRocmSkip' decorator for those tests those are failing on MI200. 
https://ontrack-internal.amd.com/browse/SWDEV-522255