### PR TITLE
MI300 expectation replacement 

### DIFF
--- a/tests/models/gemma/test_modeling_gemma.py
+++ b/tests/models/gemma/test_modeling_gemma.py
@@ -773,7 +773,4 @@ class GemmaIntegrationTest(unittest.TestCase):
             **inputs, max_new_tokens=20, do_sample=False, dola_layers="low", repetition_penalty=1.2
         )
         output_text = tokenizer.batch_decode(output, skip_special_tokens=True)
-        print("*** Actual output:")
-        print(f"{output_text[0]=}")
-        print(f"{output_text[1]=}")
         self.assertEqual(output_text, EXPECTED_TEXTS)


### PR DESCRIPTION
Replace expectation for MI300 in the test `tests/models/gemma/test_modeling_gemma.py::GemmaIntegrationTest::test_model_2b_bf16_dola`.

Following the example set in other tests defined in the class, the CUDA compute capability major version 9 is used for differentiating MI300.
